### PR TITLE
Bug/access key could not be set on key create function

### DIFF
--- a/adminapi_integration_test.go
+++ b/adminapi_integration_test.go
@@ -211,7 +211,7 @@ func (is *IntegrationsSuite) Test07Keys() {
 	generateKey := false
 	kc := &KeyCreateRequest{
 		UID:         is.i.TestUID,
-		Access:      accessKey,
+		AccessKey:   accessKey,
 		SecretKey:   secretKey,
 		GenerateKey: &generateKey,
 	}

--- a/adminapi_integration_test.go
+++ b/adminapi_integration_test.go
@@ -205,7 +205,50 @@ func (is *IntegrationsSuite) Test06Caps() {
 
 }
 
-func (is *IntegrationsSuite) Test07RmUser() {
+func (is *IntegrationsSuite) Test07Keys() {
+	accessKey := "TESTACCESSKEY"
+	secretKey := "TESTSECRETKEY"
+	generateKey := false
+	kc := &KeyCreateRequest{
+		UID:         is.i.TestUID,
+		Access:      accessKey,
+		SecretKey:   secretKey,
+		GenerateKey: &generateKey,
+	}
+
+	userKeys, err := is.aa.KeyCreate(context.Background(), kc)
+	is.NoError(err, "Unexpected error adding key")
+	found := false
+	for _, key := range userKeys {
+		if key.AccessKey == accessKey && key.SecretKey == secretKey {
+			found = true
+			break
+		}
+	}
+	is.True(found, "could not find the key we just added")
+
+	// now try to remove the key
+	kr := &KeyRmRequest{
+		AccessKey: accessKey,
+	}
+
+	err1 := is.aa.KeyRm(context.Background(), kr)
+	is.NoError(err1, "Unexpected error deleting key")
+
+	// check if the key was really deleted
+	userInfo, err2 := is.aa.UserInfo(context.Background(), is.i.TestUID)
+	is.NoError(err2, "Unexpected error reading user info")
+	found = false
+	for i := range userInfo.Keys {
+		if ok := userInfo.Keys[i].AccessKey == accessKey; ok {
+			found = true
+			break
+		}
+	}
+	is.False(found, "still could find the key we just deleted")
+}
+
+func (is *IntegrationsSuite) Test08RmUser() {
 	leave := os.Getenv("LEAVE_USER")
 	if leave != "" {
 		l, _ := strconv.ParseBool(leave)

--- a/key.go
+++ b/key.go
@@ -8,9 +8,9 @@ import (
 type KeyCreateRequest struct {
 	UID         string `url:"uid" validate:"required"`
 	SubUser     string `url:"subuser,omitempty"`
+	AccessKey   string `url:"access-key,omitempty"`
 	SecretKey   string `url:"secret-key,omitempty"`
 	KeyType     string `url:"key-type,omitempty" validate:"omitempty,eq=s3|eq=swift"`
-	Access      string `url:"access,omitempty" validate:"omitempty,eq=read|eq=write|eq=readwrite|eq=full"`
 	GenerateKey *bool  `url:"generate-key,omitempty"` // defaults to true
 }
 


### PR DESCRIPTION
'KeyCreate' function does not set 'AccessKey' parameter. It has an incorrect 'Access' parameter (read|write|readwrite|full) which doesn't exists in CREATE KEY Request from CEPH Admin Ops API:
http://docs.ceph.com/docs/master/radosgw/adminops/#create-key